### PR TITLE
Make demo1.scm executable and add a reference to the example

### DIFF
--- a/demo1.scm
+++ b/demo1.scm
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+# -*- scheme -*-
+exec -a demo1.scm guile -L "$(dirname "$(realpath "$0")")" "$0"
+;; !#
 ;; demo1.scm - yaml demo
 
 (add-to-load-path (getcwd))

--- a/demo1.yml
+++ b/demo1.yml
@@ -1,9 +1,9 @@
 --- 
  doe: "a deer, a female deer"
  ray: "a drop of golden sun"
- pi: 3.14159
- xmas: true
- french-hens: 3
+ pi: &pi 3.14159
+ xmas: &xmas true
+ xpi: *pi
  calling-birds: 
    - huey
    - dewey

--- a/demo1.yml
+++ b/demo1.yml
@@ -3,6 +3,7 @@
  ray: "a drop of golden sun"
  pi: &pi 3.14159
  xmas: true
+ french-hens: 3
  xpi: *pi
  calling-birds: 
    - huey

--- a/demo1.yml
+++ b/demo1.yml
@@ -2,7 +2,7 @@
  doe: "a deer, a female deer"
  ray: "a drop of golden sun"
  pi: &pi 3.14159
- xmas: &xmas true
+ xmas: true
  xpi: *pi
  calling-birds: 
    - huey


### PR DESCRIPTION
This uses bash-indirection, because it allows setting the library path.